### PR TITLE
MH-18005: add keycloak option to use mayhem token

### DIFF
--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/ConfigurationProperties.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/ConfigurationProperties.java
@@ -15,6 +15,8 @@ public final class ConfigurationProperties {
     public static final String API_HTTP_BASIC_ENABLED_PROPERTY = "API_HTTP_BASIC_ENABLED";
     public static final String API_HTTP_BASIC_USERNAME_PROPERTY = "API_HTTP_BASIC_USERNAME";
     public static final String API_HTTP_BASIC_PASSWORD_PROPERTY = "API_HTTP_BASIC_PASSWORD";
+    public static final String MAYHEM_TOKEN_PROPERTY = "MAYHEM_TOKEN";
+    public static final String MAYHEM_TOKEN_ENABLED_PROPERTY = "MAYHEM_TOKEN_ENABLED";
     public static final String USE_USER_ID_FOR_CREDENTIAL_VERIFICATION = "USE_USER_ID_FOR_CREDENTIAL_VERIFICATION";
     public static final String ROLE_MAP_PROPERTY = "ROLE_MAP";
     public static final String GROUP_MAP_PROPERTY = "GROUP_MAP";
@@ -26,6 +28,14 @@ public final class ConfigurationProperties {
                     "Rest client URI (required)",
                     "URI of the legacy system endpoints",
                     STRING_TYPE, null),
+            new ProviderConfigProperty(MAYHEM_TOKEN_ENABLED_PROPERTY,
+                    "Rest client Mayhem token auth enabled",
+                    "Enables Mayhem token authentication for legacy user service",
+                    BOOLEAN_TYPE, false),
+            new ProviderConfigProperty(MAYHEM_TOKEN_PROPERTY,
+                    "Rest client Mayhem token",
+                    "Mayhem token",
+                    PASSWORD, null),
             new ProviderConfigProperty(API_TOKEN_ENABLED_PROPERTY,
                     "Rest client Bearer token auth enabled",
                     "Enables Bearer token authentication for legacy user service",

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
@@ -28,6 +28,7 @@ public class RestUserService implements LegacyUserService {
 
         configureBasicAuth(model, httpClient);
         configureBearerTokenAuth(model, httpClient);
+        configureMayhemTokenAuth(model, httpClient);
     }
 
     private void configureBasicAuth(ComponentModel model, HttpClient httpClient) {
@@ -45,6 +46,14 @@ public class RestUserService implements LegacyUserService {
         if (tokenAuthEnabled) {
             String token = model.getConfig().getFirst(API_TOKEN_PROPERTY);
             httpClient.enableBearerTokenAuth(token);
+        }
+    }
+
+    private void configureMayhemTokenAuth(ComponentModel model, HttpClient httpClient) {
+        var mayhemTokenAuthEnabled = Boolean.parseBoolean(model.getConfig().getFirst(MAYHEM_TOKEN_ENABLED_PROPERTY));
+        if (mayhemTokenAuthEnabled) {
+            String token = model.getConfig().getFirst(MAYHEM_TOKEN_PROPERTY);
+            httpClient.enableMayhemTokenAuth(token);
         }
     }
 

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/http/HttpClient.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/http/HttpClient.java
@@ -25,6 +25,8 @@ public class HttpClient {
     private static final String BEARER_FORMAT = "Bearer %s";
     private static final String BASIC_AUTH_FORMAT = "Basic %s";
     private static final String USERNAME_PASSWORD_FORMAT = "%s:%s";
+    private static final String MAYHEM_TOKEN_HEADER = "X-Mayhem-Token";
+    private static final String MAYHEM_AUTH_FORMAT = "token %s";
 
     private final HttpClientBuilder httpClientBuilder;
 
@@ -48,6 +50,13 @@ public class HttpClient {
     public void enableBearerTokenAuth(String token) {
         if (token != null && !token.isBlank()) {
             var authorizationHeader = new BasicHeader(HttpHeaders.AUTHORIZATION, String.format(BEARER_FORMAT, token));
+            httpClientBuilder.setDefaultHeaders(List.of(authorizationHeader));
+        }
+    }
+
+    public void enableMayhemTokenAuth(String token) {
+        if (token != null && !token.isBlank()) {
+            var authorizationHeader = new BasicHeader(MAYHEM_TOKEN_HEADER, String.format(MAYHEM_AUTH_FORMAT, token));
             httpClientBuilder.setDefaultHeaders(List.of(authorizationHeader));
         }
     }


### PR DESCRIPTION
Currently the migration plugin can only add `Authorization: Bearer <token>` header, but we need `X-Mayhem-Token: token <token>` to have Service account in Mayhem